### PR TITLE
Deluge doesn't work with initial compose config

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ services:
     container_name: deluge
     image: linuxserver/deluge:latest
     restart: always
-    network_mode: service:vpn # run on the vpn network
+    network_mode: host # run locally until the vpn network is set up
     environment:
       - PUID=${PUID} # default user id, defined in .env 
       - PGID=${PGID} # default group id, defined in .env


### PR DESCRIPTION
Since the VPN isn't set up, Deluge won't actually start. This sets it to `host`

You might also consider calling out the `Notice how deluge is now using the vpn container network, with deluge web UI port exposed on the vpn container for local network access.` part because people may miss this step