### PR TITLE
Corrected Plex server UI URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -492,7 +492,7 @@ Let's run it !
 
 #### Configuration
 
-Plex Web UI should be available at `localhost:32400` (replace `localhost` by your server ip if needed).
+Plex Web UI should be available at `localhost:32400/web` (replace `localhost` by your server ip if needed).
 You'll have to login first (registration is free), then Plex will ask you to add your libraries.
 I have two libraries:
 


### PR DESCRIPTION
The Plex server web UI is at http://ip-address:32400/web


See for example these sources:

* https://forums.plex.tv/t/192-168-x-x-32400-displays-this-xml-file-does-not-appear-to-have-any-style-information/178043/2
* https://forums.plex.tv/t/pms-returning-xml-only-when-web-client-expected/285909/3