### PR TITLE
Remove port binding from bazarr container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -111,5 +111,3 @@ services:
       - ${ROOT}/config/bazarr:/config # config files
       - ${ROOT}/complete/movies:/movies # movies folder
       - ${ROOT}/complete/tv:/tv # tv shows folder
-    ports:
-      - 6767:6767


### PR DESCRIPTION
Remove the port binding from the bazarr container, as it's connected to the host network

The docker-compose won't launch if we don't remove it