### PR TITLE
replace nzbget with sabzbd

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,9 +42,9 @@ services:
       - ${ROOT}/downloads/torrent-blackhole:/downloads # place where to put .torrent files for manual download
       - ${ROOT}/config/jackett:/config # config files
 
-  nzbget:
-    container_name: nzbget
-    image: linuxserver/nzbget:latest
+  sabnzbd:
+    container_name: sabnzbd
+    image: lscr.io/linuxserver/sabnzbd:latest
     restart: unless-stopped
     network_mode: host
     environment:
@@ -53,7 +53,7 @@ services:
       - TZ=${TZ} # timezone, defined in .env
     volumes:
       - ${ROOT}/downloads:/downloads # download folder
-      - ${ROOT}/config/nzbget:/config # config files
+      - ${ROOT}/config/sabnzbd:/config # config files
 
   sonarr:
     container_name: sonarr


### PR DESCRIPTION
addresses deprecation issue #84 

minor issue that the default port for sabzbd is 8080, a popular port on most servers