### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
     cap_add:
       - net_admin # required to modify network interfaces
     restart: unless-stopped
+    devices:
+      - /dev/net/tun:/dev/net/tun
     volumes:
       - /dev/net:/dev/net:z # tun device
       - ${ROOT}/config/vpn:/vpn # OpenVPN configuration


### PR DESCRIPTION
update of containerd.io to fix VPN network causing TUN/TAP dev /dev/net/tun: Operation not permitted (errno=1).

Tested with Docker on Proxmox 8 kernel 6.11